### PR TITLE
Auto deploy does not remove spec files anymore.

### DIFF
--- a/deployment/server_unpacking.sh
+++ b/deployment/server_unpacking.sh
@@ -3,11 +3,19 @@ set -eo pipefail
 
 cd ~/staging-docs.myparcel.com
 
-echo "Removing current files..."
+echo "Backing up spec files"
+mv public/api-specification api-spec
+mv public/carrier-specification carrier-spec
+
+echo "Removing current files"
 rm -rf public
 
-echo "Unpacking files..."
+echo "Unpacking files"
 tar -xzvf export.tar.gz
 
-echo "Removing uploaded bundle..."
+echo "Putting spec files back"
+mv api-spec public/api-specification
+mv carrier-spec public/carrier-specification
+
+echo "Removing uploaded bundle"
 rm ./export.tar.gz


### PR DESCRIPTION
Auto deploy was removing everything including possible spec files.
This fixes it.