### PR TITLE
MP-2225 Address object should reflect API Address

### DIFF
--- a/content/api/rpc-endpoints/suggest-addess.md
+++ b/content/api/rpc-endpoints/suggest-addess.md
@@ -14,12 +14,11 @@ The attributes that are required for an address suggestion differ per country. T
 
 **Required Scope:** `addresses.suggest`
 
-| Attribute              | Type   | Required |
-|------------------------|--------|----------|
-| `country_code`         | string | ✓        |
-| `postal_code`          | string |          |
+| Attribute              | Type    | Required |
+|------------------------|---------|----------|
+| `country_code`         | string  | ✓        |
+| `postal_code`          | string  |          |
 | `street_number`        | integer |          |
-| `street_number_suffix` | string |          |
 
 ```http
 POST /suggest-address HTTP/1.1
@@ -31,8 +30,7 @@ Example: https://sandbox-api.myparcel.com/suggest-address
   "data": {
     "country_code": "NL",
     "postal_code": "2131 BC",
-    "street_number": 679,
-    "street_number_suffix": "A1"
+    "street_number": 679
   }
 }
 ```
@@ -41,14 +39,15 @@ Example: https://sandbox-api.myparcel.com/suggest-address
 
 The API will try to suggest all possible matches using the data provided.
 
-| Attribute              | Type   | Required |
-|------------------------|--------|----------|
-| `country_code`         | string | ✓        |
-| `postal_code`          | string |          |
+| Attribute              | Type    | Required |
+|------------------------|---------|----------|
+| `country_code`         | string  | ✓        |
+| `postal_code`          | string  |          |
 | `street_number`        | integer |          |
-| `street_number_suffix` | string |          |
-| `city`                 | string |          |
-| `street_name`          | string |          |
+| `street_number_suffix` | string  |          |
+| `city`                 | string  |          |
+| `street_1`             | string  |          |
+| `street_2`             | string  |          |
 
 ```json
 {
@@ -57,9 +56,10 @@ The API will try to suggest all possible matches using the data provided.
       "country_code": "NL",
       "postal_code": "2131 BC",
       "street_number": 679,
+      "street_number_suffix": "A1",
       "city": "Hoofddorp",
-      "street_name": "Hoofdweg",
-      "street_number_suffix": "A1"
+      "street_1": "Hoofdweg",
+      "street_2": "Haarlemmermeer"
     }
   ]
 }

--- a/content/api/rpc-endpoints/suggest-addess.md
+++ b/content/api/rpc-endpoints/suggest-addess.md
@@ -8,6 +8,10 @@ weight = 7
 
 To make sure the correct address is being used for a shipment, the `suggest-address` endpoint allows you to verify and possibly suggest the address of a shipment. This endpoints differs a bit from the other endpoints, since it is an [RPC endpoint](/api/rpc-endpoints).
 
+{{% notice info %}}
+For now, the only supported country to suggest addresses for is the Netherlands (NL).
+{{% /notice %}}
+
 ## Request
 
 The attributes that are required for an address suggestion differ per country. The endpoint will respond with a `422 Unprocessable Entity` when not all required attributes are supplied for the country and will list all required attributes.

--- a/content/api/rpc-endpoints/suggest-addess.md
+++ b/content/api/rpc-endpoints/suggest-addess.md
@@ -17,8 +17,8 @@ The attributes that are required for an address suggestion differ per country. T
 | Attribute              | Type    | Required |
 |------------------------|---------|----------|
 | `country_code`         | string  | ✓        |
-| `postal_code`          | string  |          |
-| `street_number`        | integer |          |
+| `postal_code`          | string  | ✓        |
+| `street_number`        | integer | ✓        |
 
 ```http
 POST /suggest-address HTTP/1.1


### PR DESCRIPTION
**Changes**
- Renamed `street_name` to `street_1`.
- Added `street_2` to response address.
- Removed `street_number_suffix` from request example since it's not implemented.