### PR TITLE
:green_heart: update theme version in build file

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p themes \
     && rm -rf hugo-theme-docdock \
     && git clone https://github.com/vjeantet/hugo-theme-docdock.git \
     && cd hugo-theme-docdock \
-    && git checkout tags/v1
+    && git checkout tags/v1.1
 
 ADD . /opt/hugo
 


### PR DESCRIPTION
We need to use theme `v1.1` because we updated Hugo.
This was changed in the mp script but not in the Dockerfile.