### PR TITLE
MP-2433 - Fix hook-logs examples

### DIFF
--- a/content/api/create-a-shipment/_index.md
+++ b/content/api/create-a-shipment/_index.md
@@ -338,9 +338,6 @@ Content-Type: application/vnd.api+json
       },
       "register_at": 1504801719
     },
-    "links": {
-      "self": "https://sandbox-api.myparcel.com/shipments/6b5db4f9-37ea-437a-b2f9-7f2d146d5bb8"
-    },
     "relationships": {
       "shop": {
         "data": {
@@ -377,12 +374,11 @@ Content-Type: application/vnd.api+json
         "links": {
           "related": "https://sandbox-api.myparcel.com/shipments/6b5db4f9-37ea-437a-b2f9-7f2d146d5bb8/statuses/5781d596-1bf2-44ba-bcaf-d356117cbb94"
         }
-      },
-      "files": {
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/shipments/6b5db4f9-37ea-437a-b2f9-7f2d146d5bb8/files"
-        }
       }
+    },
+    "links": {
+      "self": "https://sandbox-api.myparcel.com/shipments/6b5db4f9-37ea-437a-b2f9-7f2d146d5bb8",
+      "files": "https://sandbox-api.myparcel.com/shipments/6b5db4f9-37ea-437a-b2f9-7f2d146d5bb8/files"
     }
   }
 }

--- a/content/api/resources/hooks/logs.md
+++ b/content/api/resources/hooks/logs.md
@@ -7,10 +7,11 @@ weight = 3
 A hook log specifies what happened when the hook was executed.
 
 ## Attributes
-| Attribute       | Type              | Description                                                                                   | Required |
-| --------------- | ----------------- | ----------------------------------------------------------------------------------------------| -------- |
-| resource_diff   | object            | An object of the changes done on this resource.                                               |          |
-| errors          | array of strings  | An array of strings containing the error that was encountered while trying to run this hook.  |          |
+
+| Attribute     | Type             | Description                                                                                  | Required |
+| ------------- | ---------------- | -------------------------------------------------------------------------------------------- | -------- |
+| resource_diff | object           | An object of the changes done on this resource.                                              |          |
+| errors        | array of strings | An array of strings containing the error that was encountered while trying to run this hook. |          |
 
 {{% notice warning %}}
 This resource is still experimental so it requires the `experimental` scope and might still change in the future.
@@ -20,7 +21,7 @@ This resource is still experimental so it requires the `experimental` scope and 
 
 **Request**
 ```http
-GET /hook-logs HTTP/1.1
+GET /hook-logs/{hook_log_id} HTTP/1.1
 Accept: application/vnd.api+json
 Example: https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97469b10ce
 ```
@@ -28,54 +29,41 @@ Example: https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97
 **Successful hooks response example**
 ```json
 {
-  "data": [
-    {
-      "type": "hook-logs",
-      "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce",
-      "attributes": {
-        "resource_diff": {
-          "relationships": {
-             "service": {
-               "data": {
-                 "type": "services",
-                 "id": "7b808eee-bf1c-40cd-98f2-3c335a06417e"
-               }
-             }
-           }
+  "data": {
+    "type": "hook-logs",
+    "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce",
+    "attributes": {
+      "resource_diff": {
+        "relationships": {
+          "service": {
+            "data": {
+              "type": "services",
+              "id": "7b808eee-bf1c-40cd-98f2-3c335a06417e"
+            }
+          }
+        }
+      }
+    },
+    "relationships": {
+      "hook": {
+        "data": {
+          "id": "be7f6752-34e0-49a1-a832-bcc209450ea9",
+          "type": "hooks"
+        },
+        "links": {
+          "related": "https://localhost:9443/hooks/be7f6752-34e0-49a1-a832-bcc209450ea9"
         }
       },
-      "links": {
-        "self": "https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97469b10ce"
-      },
-      "relationships": {
-          "hook": {
-              "data": {
-                  "id": "be7f6752-34e0-49a1-a832-bcc209450ea9",
-                  "type": "hooks"
-              },
-              "links": {
-                  "related": "https://localhost:9443/hooks/be7f6752-34e0-49a1-a832-bcc209450ea9"
-              }
-          },
-          "resource": {
-              "data": {
-                  "type": "shipments",
-                  "id": "7b808eee-bf1c-40cd-98f2-3c335a06417e"
-              }
-          }
+      "resource": {
+        "data": {
+          "type": "shipments",
+          "id": "7b808eee-bf1c-40cd-98f2-3c335a06417e"
+        }
       }
+    },
+    "links": {
+      "self": "https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97469b10ce"
     }
-  ],
-  "meta": {
-    "total_pages": 13,
-    "total_records": 373
-  },
-  "links": {
-    "self": "https://sandbox-api.myparcel.com/hook-logs?page[number]=3&page[size]=30",
-    "first": "https://sandbox-api.myparcel.com/hook-logs?page[number]=1&page[size]=30",
-    "prev": "https://sandbox-api.myparcel.com/hook-logs?page[number]=2&page[size]=30",
-    "next": "https://sandbox-api.myparcel.com/hook-logs?page[number]=4&page[size]=30",
-    "last": "https://sandbox-api.myparcel.com/hook-logs?page[number]=13&page[size]=30"
   }
 }
 ```
@@ -83,47 +71,34 @@ Example: https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97
 **Failed hooks response example**
 ```json
 {
-  "data": [
-    {
-      "type": "hook-logs",
-      "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce",
-      "attributes": {
-        "errors": [
-           "Applying the hook failed because the desired service was not available for the shipment contract."
-         ]
+  "data": {
+    "type": "hook-logs",
+    "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce",
+    "attributes": {
+      "errors": [
+        "Applying the hook failed because the desired service was not available for the shipment contract."
+      ]
+    },
+    "relationships": {
+      "hook": {
+        "data": {
+          "id": "be7f6752-34e0-49a1-a832-bcc209450ea9",
+          "type": "hooks"
+        },
+        "links": {
+          "related": "https://localhost:9443/hooks/be7f6752-34e0-49a1-a832-bcc209450ea9"
+        }
       },
-      "links": {
-        "self": "https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97469b10ce"
-      },
-      "relationships": {
-          "hook": {
-              "data": {
-                  "id": "be7f6752-34e0-49a1-a832-bcc209450ea9",
-                  "type": "hooks"
-              },
-              "links": {
-                  "related": "https://localhost:9443/hooks/be7f6752-34e0-49a1-a832-bcc209450ea9"
-              }
-          },
-          "resource": {
-              "data": {
-                  "type": "shipments",
-                  "id": "7b808eee-bf1c-40cd-98f2-3c335a06417e"
-              }
-          }
+      "resource": {
+        "data": {
+          "type": "shipments",
+          "id": "7b808eee-bf1c-40cd-98f2-3c335a06417e"
+        }
       }
+    },
+    "links": {
+      "self": "https://sandbox-api.myparcel.com/hook-logs/8e141db6-d638-9ae0-e33d-8e97469b10ce"
     }
-  ],
-  "meta": {
-    "total_pages": 13,
-    "total_records": 373
-  },
-  "links": {
-    "self": "https://sandbox-api.myparcel.com/hook-logs?page[number]=3&page[size]=30",
-    "first": "https://sandbox-api.myparcel.com/hook-logs?page[number]=1&page[size]=30",
-    "prev": "https://sandbox-api.myparcel.com/hook-logs?page[number]=2&page[size]=30",
-    "next": "https://sandbox-api.myparcel.com/hook-logs?page[number]=4&page[size]=30",
-    "last": "https://sandbox-api.myparcel.com/hook-logs?page[number]=13&page[size]=30"
   }
 }
 ```

--- a/content/api/resources/service-rates.md
+++ b/content/api/resources/service-rates.md
@@ -103,9 +103,6 @@ Example: https://sandbox-api.myparcel.com/service-rates
             {
               "type": "service-options",
               "id": "4c675b1a-516c-4410-abff-d237fd45bcd0",
-              "links": {
-                "self": "https://sandbox-api.myparcel.com/service-options/4c675b1a-516c-4410-abff-d237fd45bcd0"
-              },
               "meta": {
                 "price": {
                   "amount": 995,
@@ -114,10 +111,7 @@ Example: https://sandbox-api.myparcel.com/service-rates
                 "included": true
               }
             }
-          ],
-          "links": {
-            "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-          }
+          ]
         }
       },
       "links": {
@@ -203,9 +197,6 @@ Example: https://sandbox-api.myparcel.com/service-rates/09a8f83a-bc8d-4598-81e6-
           {
             "type": "service-options",
             "id": "4c675b1a-516c-4410-abff-d237fd45bcd0",
-            "links": {
-              "self": "https://sandbox-api.myparcel.com/service-options/4c675b1a-516c-4410-abff-d237fd45bcd0"
-            },
             "meta": {
               "price": {
                 "amount": 995,
@@ -214,10 +205,7 @@ Example: https://sandbox-api.myparcel.com/service-rates/09a8f83a-bc8d-4598-81e6-
               "included": true
             }
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-        }
+        ]
       }
     },
     "links": {

--- a/content/api/resources/shipments/_index.md
+++ b/content/api/resources/shipments/_index.md
@@ -165,15 +165,9 @@ Example: https://sandbox-api.myparcel.com/shipments
           "data": [
             {
               "type": "service-options",
-              "id": "4c675b1a-516c-4410-abff-d237fd45bcd0",
-              "links": {
-                "self": "https://sandbox-api.myparcel.com/service-options/4c675b1a-516c-4410-abff-d237fd45bcd0"
-              }
+              "id": "4c675b1a-516c-4410-abff-d237fd45bcd0"
             }
-          ],
-          "links": {
-            "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-          }
+          ]
         },
         "service": {
           "data": {
@@ -217,22 +211,20 @@ Example: https://sandbox-api.myparcel.com/shipments
               "type": "files",
               "id": "0f621db6-d239-4ae9-b85d-8e97469b10ce"
             }
-          ],
-          "links": {
-            "related": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
-          }
+          ]
         },
         "hook_logs": {
           "data": [
             {
-              "type": "hook_logs",
+              "type": "hook-logs",
               "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce"
             }
           ]
         }
       },
       "links": {
-        "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e"
+        "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e",
+        "files": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
       }
     },
     {
@@ -338,15 +330,9 @@ Example: https://sandbox-api.myparcel.com/shipments
           "data": [
             {
               "type": "service-options",
-              "id": "4c675b1a-516c-4410-abff-d237fd45bcd0",
-              "links": {
-                "self": "https://sandbox-api.myparcel.com/service-options/4c675b1a-516c-4410-abff-d237fd45bcd0"
-              }
+              "id": "4c675b1a-516c-4410-abff-d237fd45bcd0"
             }
-          ],
-          "links": {
-            "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-          }
+          ]
         },
         "service": {
           "data": {
@@ -390,22 +376,20 @@ Example: https://sandbox-api.myparcel.com/shipments
               "type": "files",
               "id": "0f621db6-d239-4ae9-b85d-8e97469b10ce"
             }
-          ],
-          "links": {
-            "related": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
-          }
+          ]
         },
         "hook_logs": {
           "data": [
             {
-              "type": "hook_logs",
+              "type": "hook-logs",
               "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce"
             }
           ]
         }
       },
       "links": {
-        "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e"
+        "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e",
+        "files": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
       }
     }
   ],
@@ -560,10 +544,7 @@ Example: https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c33
             "type": "service-options",
             "id": "4c675b1a-516c-4410-abff-d237fd45bcd0"
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-        }
+        ]
       },
       "shop": {
         "data": {
@@ -607,22 +588,20 @@ Example: https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c33
             "type": "files",
             "id": "0f621db6-d239-4ae9-b85d-8e97469b10ce"
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
-        }
+        ]
       },
       "hook_logs": {
         "data": [
           {
-            "type": "hook_logs",
+            "type": "hook-logs",
             "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce"
           }
         ]
       }
     },
     "links": {
-      "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e"
+      "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e",
+      "files": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
     }
   }
 }
@@ -896,10 +875,7 @@ Example: https://sandbox-api.myparcel.com/shipments
             "type": "service-options",
             "id": "4c675b1a-516c-4410-abff-d237fd45bcd0"
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-        }
+        ]
       },
       "shop": {
         "data": {
@@ -943,22 +919,20 @@ Example: https://sandbox-api.myparcel.com/shipments
             "type": "files",
             "id": "0f621db6-d239-4ae9-b85d-8e97469b10ce"
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
-        }
+        ]
       },
       "hook_logs": {
         "data": [
           {
-            "type": "hook_logs",
+            "type": "hook-logs",
             "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce"
           }
         ]
       }
     },
     "links": {
-      "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e"
+      "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e",
+      "files": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
     }
   }
 }
@@ -1124,10 +1098,7 @@ Example: https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c33
             "type": "service-options",
             "id": "4c675b1a-516c-4410-abff-d237fd45bcd0"
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/service-contracts/af5e65b6-a709-4f61-a565-7c12a752482f/options"
-        }
+        ]
       },
       "shop": {
         "data": {
@@ -1171,22 +1142,20 @@ Example: https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c33
             "type": "files",
             "id": "0f621db6-d239-4ae9-b85d-8e97469b10ce"
           }
-        ],
-        "links": {
-          "related": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
-        }
+        ]
       },
       "hook_logs": {
         "data": [
           {
-            "type": "hook_logs",
+            "type": "hook-logs",
             "id": "8e141db6-d638-9ae0-e33d-8e97469b10ce"
           }
         ]
       }
     },
     "links": {
-      "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e"
+      "self": "https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e",
+      "files": "https://sandbox-api.myparcel.com/shipments/0f621db6-d239-4ae9-b85d-8e97469b10ce/files"
     }
   }
 }


### PR DESCRIPTION
- Fixed `hook-logs` response examples.
- Updated `hook_logs` types to `hook-logs`.
- Moved old `relationships.files.links.related` links to `links.files`.
- Removed non-existing links from `service_options` relationships.