### PR TITLE
📌 switched to stable nginx branch

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -24,7 +24,7 @@ ADD . /opt/hugo
 
 RUN hugo --baseURL "https://${DOMAIN}/"
 
-FROM nginx:1.15-alpine
+FROM nginx:1.16-alpine
 
 COPY --from=build /opt/hugo/public /usr/share/nginx/html
 


### PR DESCRIPTION
https://www.nginx.com/blog/nginx-1-16-1-17-released/
> Stable receives fixes for high‑severity bugs, but is not updated with new features. It is denoted by an even number in the second part of the version number, for example 1.16.0.