### PR TITLE
MP-3142 📝 Changed shipment status update functionality

### DIFF
--- a/content/api/retrieve-shipment-files.md
+++ b/content/api/retrieve-shipment-files.md
@@ -30,13 +30,6 @@ Method               | Description | Documentation
 Webhooks (preferred) | **Our system** will notify **your system** as soon as the status is changed. | [Create a webhook](/api/create-a-webhook)
 Polling              | **Your system** should retrieve the shipment statuses from **our system**<br>and retry this (after waiting 1 second) if the status is not yet updated. | [Retrieve current status](/api/retrieve-shipment-statuses/#current-status)
 
-{{% notice warning %}}
-In some exceptional cases, the status of a shipment will not change from `shipment-concept` to either `shipment-registered` or `shipment-registration-failed`, but rather stay `shipment-concept`. 
-This is the result of an internal error (or external in case the carrier's services are not available). 
-Our team will get notified of when this happens and try and resolve the issue as soon as possible.
-{{% /notice %}}
-
-
 ## Retrieving available files
 
 Before you can download a file, you should check what files are available for the given shipment. To request the files, send a `GET` request to `/shipments/{shipment_id}/files`.

--- a/content/api/rpc-endpoints/suggest-address.md
+++ b/content/api/rpc-endpoints/suggest-address.md
@@ -6,7 +6,7 @@ weight = 7
 
 {{< icon fa-file-text-o >}}[API specification](https://docs.myparcel.com/api-specification#/RPC/post_suggest_address)
 
-To make sure the correct address is being used for a shipment, the `suggest-address` endpoint allows you to verify and possibly suggest the address of a shipment. This endpoints differs a bit from the other endpoints, since it is an [RPC endpoint](/api/rpc-endpoints).
+To make sure the correct address is being used for a shipment, the `suggest-address` endpoint allows you to verify and possibly suggest the address of a shipment.
 
 {{% notice info %}}
 For now, the only supported country to suggest addresses for is the Netherlands (NL).

--- a/content/api/rpc-endpoints/update-shipment-statuses.md
+++ b/content/api/rpc-endpoints/update-shipment-statuses.md
@@ -6,29 +6,29 @@ weight = 8
 
 {{< icon fa-file-text-o >}}[API specification](https://docs.myparcel.com/api-specification#/RPC/post_update_shipment_status)
 
-{{% notice warning %}}
-This endpoint is only available for the **sandbox** environment!
-{{% /notice %}}
+The `update-shipment-status` endpoint allows you to trigger an update of a shipment's status. The shipment will be synchronized with the carrier.
 
-When implementing the MyParcel.com API using the sandbox environment, you might want to simulate realistic shipment behavior like changing a shipment's status.
-Because the sandbox environment doesn't actually allow users to send a shipment, shipments will never receive a status update from the carrier, indicating that it is on the way or has been delivered etc. To simulate this behavior, the sandbox environment describes an [RPC endpoint](/api/rpc-endpoints) that allows users to manually update the status of a shipment. 
+### Sandbox environment
+
+Since our sandbox environment does not provide real shipments, they will never receive a status update from the carrier.
+To simulate a status update, you can provide a `status_id` in sandbox requests.
+This way you can simulate realistic shipment behavior and trigger webhooks to test your implementation.
+
+{{% notice warning %}}
+The MyParcel.com API contains several [status](/api/resources/statuses) resources that are not related to shipments. 
+When calling the /update-shipment-status endpoint, please make sure the posted status is a shipment related status (indicated by the `resource_type` attribute). 
+{{% /notice %}}
 
 ## Request
 
 **Required Scope:** `shipments.manage`
 
-| Attribute              | Type                     | Required |
-|------------------------|--------------------------|----------|
-| `shipment_id`          | uuid formatted string    | ✓        |
-| `status_id`            | uuid formatted string    | ✓        |
+| Attribute     | Type                                                                  | Required |
+|---------------|-----------------------------------------------------------------------|----------|
+| `shipment_id` | uuid formatted string                                                 | ✓        |
+| `status_id`   | uuid formatted string (only available on the **sandbox** environment) |          |
 
-This endpoint allows a user to create a new [shipment-status](/api/resources/shipment-statuses) consisting of the posted [shipment](/api/resources/shipments) and [status](/api/resources/statuses). 
-
-{{% notice warning %}}
-The MyParcel.com API contains several resources that are not related to shipments. 
-When calling the /update-shipment-status endpoint, please make sure the posted status is a shipment related status (indicated by the [status](/api/resources/statuses) `resource_type` attribute). 
-{{% /notice %}}
-
+Using this endpoint will result in a new [shipment-status](/api/resources/shipment-statuses) added to the posted [shipment](/api/resources/shipments), if the new status is different from the current status.
 
 ```http
 POST /update-shipment-status HTTP/1.1


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-3142
- Remove warning for shipment statuses not updating upon internal server errors.
- Rewrite documentation of `/update-shipment-status` RPC endpoint.