### PR TITLE
📝 Add fuel_surcharge to service-rate resource

### DIFF
--- a/content/api/resources/service-rates.md
+++ b/content/api/resources/service-rates.md
@@ -11,22 +11,23 @@ A user has access to service rates that are related to the contracts the user ha
 
 {{< icon fa-file-text-o >}}[API specification](https://api-specification.myparcel.com/#tag/Shops)
 
-Attribute  |  Type   | Description                                              | Required
----------- | ------- | ------------------------------------------------------------------------------------------- | --------
-weight_min | integer | The minimum weight in grams a shipment should have for this service rate to apply to it.     | ✓
-weight_max | integer | The maximum weight in grams a shipment should have for this service rate to apply to it.     | ✓
-length_max | integer | The maximum length of the shipment in mm.                                                    |
-width_max  | integer | The maximum width of the shipment in mm.                                                     |
-height_max | integer | The maximum height of the shipment in mm.                                                    |
-volume_max | float   | The maximum volume of the shipment in liters.                                                |
-price      | [price](/api/resources/common-objects/prices/) | The price of the service in cents (where applicable). |
-step_size  | integer | When the service supports sending shipments that exceed the max weight, this indicates in what weight steps (in grams) the increments are calculated with. |
-step_price | [price](/api/resources/common-objects/prices/) | The price per increment of `step_size`. |
+Attribute      |  Type   | Description                                                                                   | Required
+-------------- | ------- | --------------------------------------------------------------------------------------------- | --------
+weight_min     | integer | The minimum weight in grams a shipment should have for this service rate to apply to it.      | ✓
+weight_max     | integer | The maximum weight in grams a shipment should have for this service rate to apply to it.      | ✓
+length_max     | integer | The maximum length of the shipment in mm.                                                     |
+width_max      | integer | The maximum width of the shipment in mm.                                                      |
+height_max     | integer | The maximum height of the shipment in mm.                                                     |
+volume_max     | float   | The maximum volume of the shipment in liters.                                                 |
+price          | [price](/api/resources/common-objects/prices/) | The price of the service in cents.                     |
+fuel_surcharge | [price](/api/resources/common-objects/prices/) | The additional fuel surcharge of the service in cents (not included in `price`). |
+step_size      | integer | When the service supports sending shipments that exceed the max weight, this indicates in what weight steps (in grams) the increments are calculated with. |
+step_price     | [price](/api/resources/common-objects/prices/) | The price per increment of `step_size`.                |
 
-Relationship    | Type                                                                                                | Description                          | Required
---------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------ | --------
-contract        | [contracts](/api/resources/contracts)                  | The contract this rate belongs to.    | ✓
-service         | [services](/api/resources/services/)                     | The service this rate belongs to.     | ✓
+Relationship    | Type                                               | Description                        | Required
+--------------- | -------------------------------------------------- | ---------------------------------- | --------
+contract        | [contracts](/api/resources/contracts)              | The contract this rate belongs to. | ✓
+service         | [services](/api/resources/services/)               | The service this rate belongs to.  | ✓
 service_options | [service-options](/api/resources/service-options/) | The service service options that are available for this contract and service combination. The price and whether it is always included are available in the meta. |
 
 ## Endpoints

--- a/content/api/resources/shipments/_index.md
+++ b/content/api/resources/shipments/_index.md
@@ -558,10 +558,10 @@ Example: https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c33
         "amount": 995,
         "currency": "EUR"
       },
-        "total_value": {
-          "amount": 25000,
-          "currency": "EUR"
-        },
+      "total_value": {
+        "amount": 25000,
+        "currency": "EUR"
+      },
       "barcode": "3SABCD0123456789",
       "tracking_code": "3SABCD0123456789",
       "tracking_url": "https://tracker.carrier.com/3SABCD0123456789",
@@ -924,10 +924,10 @@ Example: https://sandbox-api.myparcel.com/shipments
         "amount": 995,
         "currency": "EUR"
       },
-        "total_value": {
-          "amount": 25000,
-          "currency": "EUR"
-        },
+      "total_value": {
+        "amount": 25000,
+        "currency": "EUR"
+      },
       "barcode": "3SABCD0123456789",
       "tracking_code": "3SABCD0123456789",
       "tracking_url": "https://tracker.carrier.com/3SABCD0123456789",
@@ -1172,10 +1172,10 @@ Example: https://sandbox-api.myparcel.com/shipments/7b808eee-bf1c-40cd-98f2-3c33
         "amount": 995,
         "currency": "EUR"
       },
-        "total_value": {
-          "amount": 25000,
-          "currency": "EUR"
-        },
+      "total_value": {
+        "amount": 25000,
+        "currency": "EUR"
+      },
       "barcode": "3SABCD0123456789",
       "tracking_code": "3SABCD0123456789",
       "tracking_url": "https://tracker.carrier.com/3SABCD0123456789",

--- a/content/api/resources/shipments/items.md
+++ b/content/api/resources/shipments/items.md
@@ -14,7 +14,7 @@ Information about the contents of the shipment. Items can be included even if no
 | quantity            | integer                                        | Amount of these items present in the shipment.                                 | ✓
 | image_url           | string                                         | A link to an image of the item.                                                |
 | item_value          | [price](/api/resources/common-objects/prices/) | Value of a single item. Should be multiplied by quantity to get total value.   | (only for international shipments)
-| item_weight         | integer                                        | Weight of a single item. Should be multiplied by quantity to get total weight. | (only for international shipments)
-| hs_code             | string                                         | Harmonized System code used by customs.                                        | (only for international shipments)
+| item_weight         | integer                                        | Weight of a single item. Should be multiplied by quantity to get total weight. |
+| hs_code             | string                                         | Harmonized System code used by customs.                                        |
 | origin_country_code | string                                         | The country code in ISO 3166-1 alpha-2 format.                                 | (only for international shipments)
 | sku                 | string                                         | Unique identifier, often the Stock Keeping Unit.                               | 

--- a/content/php-sdk/common-use-case.md
+++ b/content/php-sdk/common-use-case.md
@@ -87,6 +87,7 @@ Now that you've created a shipment, you should store its `$createdShipment->getI
 ## International shipments require items and customs
 
 ```php
+use MyParcelCom\ApiSdk\Resources\Interfaces\CustomsInterface;
 use MyParcelCom\ApiSdk\Resources\Customs;
 use MyParcelCom\ApiSdk\Resources\ShipmentItem;
 
@@ -95,16 +96,23 @@ $shipment
         (new ShipmentItem())
             ->setQuantity(1)
             ->setDescription('Product 1')
-            ->setItemWeight(123),
+            ->setOriginCountryCode('NL')
+            ->setItemValue(123)
+            ->setCurrency('EUR'),
         (new ShipmentItem())
             ->setQuantity(2)
             ->setDescription('Product 2')
-            ->setItemWeight(456),
+            ->setOriginCountryCode('NL')
+            ->setItemValue(456)
+            ->setCurrency('EUR'),
     ])
     ->setCustoms(
         (new Customs())
-            ->setContentType('gifts')
-            ->setShippingValueAmount(999)
+            ->setContentType(CustomsInterface::CONTENT_TYPE_MERCHANDISE)
+            ->setInvoiceNumber('90019001')
+            ->setNonDelivery(CustomsInterface::NON_DELIVERY_RETURN)
+            ->setIncoterm(CustomsInterface::INCOTERM_DAP)
+            ->setShippingValueAmount(123)
             ->setShippingValueCurrency('EUR')
     );
 ```

--- a/content/php-sdk/common-use-case.md
+++ b/content/php-sdk/common-use-case.md
@@ -20,6 +20,7 @@ This behavior is not a problem for when you only have one shop and don't mind wh
 ```php
 use MyParcelCom\ApiSdk\Resources\Address;
 use MyParcelCom\ApiSdk\Resources\Shipment;
+use MyParcelCom\ApiSdk\Resources\PhysicalProperties;
 use MyParcelCom\ApiSdk\Resources\Interfaces\PhysicalPropertiesInterface;
 
 // Define the sender address.
@@ -45,7 +46,6 @@ $recipient
     ->setCountryCode('GB')
     ->setEmail('s.holmes@holmesinvestigations.com');
 
-
 // Get your shops from the api.
 $shops = $api->getShops();
 
@@ -58,7 +58,9 @@ $shipment
     ->setSenderAddress($sender)
     ->setRecipientAddress($recipient)
     ->setShop($myShop)
-    ->setWeight(500, PhysicalPropertiesInterface::WEIGHT_GRAM);
+    ->setPhysicalProperties(
+        (new PhysicalProperties())->setWeight(500, PhysicalPropertiesInterface::WEIGHT_GRAM)
+    );
 
 // Get the available service rates for this shipment from the API.
 $serviceRates = $api->getServiceRatesForShipment($shipment);
@@ -80,7 +82,32 @@ $shipment->setServiceCode('dpd-classic');
 $createdShipment = $api->createShipment($shipment);
 ```
 
-Now that you've created a shipment, you should store its id (`$createdShipment->getId()`) somewhere, so you can later retrieve any files associated with the shipment and check for status updates.
+Now that you've created a shipment, you should store its `$createdShipment->getId()` somewhere, so you can later retrieve any files associated with the shipment and check for status updates.
+
+## International shipments require items and customs
+
+```php
+use MyParcelCom\ApiSdk\Resources\Customs;
+use MyParcelCom\ApiSdk\Resources\ShipmentItem;
+
+$shipment
+    ->setItems([
+        (new ShipmentItem())
+            ->setQuantity(1)
+            ->setDescription('Product 1')
+            ->setItemWeight(123),
+        (new ShipmentItem())
+            ->setQuantity(2)
+            ->setDescription('Product 2')
+            ->setItemWeight(456),
+    ])
+    ->setCustoms(
+        (new Customs())
+            ->setContentType('gifts')
+            ->setShippingValueAmount(999)
+            ->setShippingValueCurrency('EUR')
+    );
+```
 
 ## Downloading the shipment label
 When you create a shipment, it's status will be `shipment_concept`. While the shipment has this status it can be modified. When you are ready to register the shipment with the carrier, you should set the `register_at` property. This can be set into the future if you want to schedule registering the shipment, or you can use the current time to register it immediately. This should normally not take more than a minute, but depending on the carrier, it can take a little bit longer.


### PR DESCRIPTION
I would suggest to activate `Hide whitespace changes` when reviewing this PR because of the changed table indentation. This makes the second file not have any changes, making GitHub show a message about "diff is too large" while the diff is non-existent.

- Added `fuel_surcharge` to service-rate resource.
- Changed some other bits (pending stuff on my local system).